### PR TITLE
Add phone number processor

### DIFF
--- a/data/unsafe-data-1.csv
+++ b/data/unsafe-data-1.csv
@@ -9,7 +9,7 @@ Banking,Afghanistan,Rempel and Sons,Eos et recusandae architecto. Laboriosam aut
 Healthcare,French Southern Territories,McKenzie Inc,Sed quo et. Eum suscipit veritatis non unde minus. Deserunt quo non inventore tempore.
 Banking,Austria,Reichel LLC,Est itaque architecto placeat recusandae. Qui odio ut est facilis quaerat occaecati velit. Sit omnis ratione.
 Banking,Equatorial Guinea,Bailey-Hudson,Ut quis et repudiandae voluptatem dignissimos. Corporis enim rerum. Id sed nemo sed voluptas ut. Vel est dolores doloribus eos accusamus sed recusandae.
-Farming,Ireland,Torp and Sons,Explicabo sed ipsam atque. Eum et ea dolor.
+Farming,Ireland,Torp and Sons,Explicabo sed ipsam atque. Eum et ea dolor. 028 9024 1234
 Education,Madagascar,Mohr Inc,In tempora unde tempore. Exercitationem harum id eveniet nesciunt quos. Excepturi sint dolor ullam non possimus sint et.
 Legal,Bouvet Island (Bouvetoya),Andres Lakin MD,Delectus molestias suscipit iure. Facere minus doloremque pariatur eos et. Sapiente et quis incidunt assumenda aut.
 Healthcare,Antigua and Barbuda,Dach-Kris,Error unde omnis possimus quis sint sit est. Adipisci consequatur architecto voluptates accusantium velit rerum. Minus quia quod. Natus quis dolor esse recusandae voluptatum ut.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,21 @@
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-2.2.0.tgz",
       "integrity": "sha512-nNXh61kEIUbTXPWPZbrKlkkylh7BDxffDUWQPWIho+Rog4XWRV8bTR8ZVo8qngzAwbhlvtKFcsaf2hGDV1iF8Q=="
     },
+    "libphonenumber-js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.1.7.tgz",
+      "integrity": "sha512-SiRBSVqGtCOdDsscrDLcMO0PpYeMHGixFGam6281AW9AlbzlviCFLDrmf2Y5VkIgYH5Y5+KKaJ/VmGK3BHAB/w==",
+      "requires": {
+        "minimist": "1.2.0",
+        "semver-compare": "1.0.0",
+        "xml2js": "0.4.19"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
@@ -39,6 +54,16 @@
         "underscore": "1.8.3",
         "webworker-threads": "0.7.13"
       }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "sylvester": {
       "version": "0.0.21",
@@ -59,6 +84,20 @@
         "bindings": "1.3.0",
         "nan": "2.10.0"
       }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/robertwpaul/lintol-challenge-1#readme",
   "dependencies": {
     "csv-parse": "^2.2.0",
+    "libphonenumber-js": "^1.1.7",
     "natural": "^0.5.6"
   }
 }

--- a/src/processors/index.js
+++ b/src/processors/index.js
@@ -1,7 +1,9 @@
 const ip = require('./ip');
+const phoneNumber = require('./phone-number');
 
 module.exports = {
   textProcessors: [
-    ip
+    ip,
+    phoneNumber
   ]
 };

--- a/src/processors/phone-number/index.js
+++ b/src/processors/phone-number/index.js
@@ -1,0 +1,27 @@
+const { isValidNumber } = require('libphonenumber-js');
+
+function hasPhoneNumbers(data) {
+  const possibilities = data.match(/[0-9+()-\s]+/g);
+  if (possibilities === null) return false;
+  return possibilities.some(num => isValidNumber(num, 'GB'))
+}
+
+function run(item) {
+  return new Promise(function(resolve) {
+    if (hasPhoneNumbers(item.data)) {
+      resolve([
+        {
+          code: 'PHONE_NUMBER_FOUND',
+          message: 'Found a phone number!',
+          item
+        }
+      ])
+    } else {
+      resolve([]);
+    }
+  });
+}
+
+module.exports = {
+  run
+}


### PR DESCRIPTION
Adds a Phone Number processor.

The `libphonenumber-js` library has a `findPhoneNumbers` function but that matches on IP addresses for some reason, so this pulls out possibles matches first and then checks any of them are valid using `isValidNumber`.